### PR TITLE
refactor: 优化 Folder Distribution 显示并移除数量限制

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,14 @@
 .vscode/**
 .vscode-test/**
+.vscode-test.mjs
 src/**
 out/**
 node_modules/**
 test_label/**
+test/**
+scripts/**
+.claude/**
+.devcontainer/**
 .gitignore
 .yarnrc
 webpack.config.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="docs/images/icon.png" width="32" height="32" alt="YOLO Label Tool Icon"> YOLO Labeling
 
 [![Publish to VS Code Marketplace](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml/badge.svg)](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml)
-[![VS Marketplace Version](https://img.shields.io/badge/VS_Marketplace-v0.0.86-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
+[![VS Marketplace Version](https://img.shields.io/badge/VS_Marketplace-v0.0.87-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS Marketplace Installs](https://img.shields.io/badge/Installs-4.5K-brightgreen?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS Marketplace Rating](https://img.shields.io/badge/Rating-5.0%2F5-yellow?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="docs/images/icon.png" width="32" height="32" alt="YOLO Label Tool Icon"> YOLO Labeling
 
 [![Publish to VS Code Marketplace](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml/badge.svg)](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml)
-[![VS Marketplace Version](https://img.shields.io/badge/VS_Marketplace-v0.0.87-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
+[![VS Marketplace Version](https://img.shields.io/badge/VS_Marketplace-v0.0.88-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS Marketplace Installs](https://img.shields.io/badge/Installs-4.5K-brightgreen?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS Marketplace Rating](https://img.shields.io/badge/Rating-5.0%2F5-yellow?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -1,7 +1,7 @@
 # <img src="./images/icon.png" width="32" height="32" alt="YOLO标注工具图标"> YOLO 标注工具
 
 [![发布到VS Code插件市场](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml/badge.svg)](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml)
-[![VS插件市场版本](https://img.shields.io/badge/VS_Marketplace-v0.0.87-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
+[![VS插件市场版本](https://img.shields.io/badge/VS_Marketplace-v0.0.88-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS插件市场安装量](https://img.shields.io/badge/安装量-4.5K-brightgreen?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS插件市场评分](https://img.shields.io/badge/评分-5.0%2F5-yellow?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![许可证: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -1,7 +1,7 @@
 # <img src="./images/icon.png" width="32" height="32" alt="YOLO标注工具图标"> YOLO 标注工具
 
 [![发布到VS Code插件市场](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml/badge.svg)](https://github.com/andaoai/yolo-label-vs/actions/workflows/main-publish.yml)
-[![VS插件市场版本](https://img.shields.io/badge/VS_Marketplace-v0.0.86-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
+[![VS插件市场版本](https://img.shields.io/badge/VS_Marketplace-v0.0.87-blue?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS插件市场安装量](https://img.shields.io/badge/安装量-4.5K-brightgreen?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![VS插件市场评分](https://img.shields.io/badge/评分-5.0%2F5-yellow?link=https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)](https://marketplace.visualstudio.com/items?itemName=andaoai.yolo-labeling-vs)
 [![许可证: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yolo-labeling-vs",
   "displayName": "YOLO Labeling",
   "description": "A VS Code extension for YOLO dataset labeling",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "publisher": "andaoai",
   "license": "MIT",
   "icon": "docs/images/icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yolo-labeling-vs",
   "displayName": "YOLO Labeling",
   "description": "A VS Code extension for YOLO dataset labeling",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "publisher": "andaoai",
   "license": "MIT",
   "icon": "docs/images/icon.png",

--- a/src/utils/dashboardHtml.ts
+++ b/src/utils/dashboardHtml.ts
@@ -600,7 +600,7 @@ export function generateDashboardHtml(
         const trainImages = ${stats.trainImages};
         const valImages = ${stats.valImages};
         const testImages = ${stats.testImages};
-        const folderDistribution = ${JSON.stringify(stats.folderDistribution.slice(0, 10))};
+        const folderDistribution = ${JSON.stringify(stats.folderDistribution)};
 
         // Chart configuration defaults
         const chartDefaults = {

--- a/src/utils/dashboardHtml.ts
+++ b/src/utils/dashboardHtml.ts
@@ -701,7 +701,8 @@ export function generateDashboardHtml(
         // ========== Chart 2: Folder Distribution (Pie) ==========
         (function() {
             const ctx = document.getElementById('folderDistributionChart').getContext('2d');
-            const folders = folderDistribution.map(f => f.folder.split('/').pop() || f.folder);
+            const folderFullPaths = folderDistribution.map(f => f.folder);
+            const folders = folderFullPaths.map(f => f.split('/').pop() || f);
             const data = folderDistribution.map(f => f.count);
             const folderColors = colors.slice(0, folders.length);
 
@@ -728,7 +729,7 @@ export function generateDashboardHtml(
                                 label: function(context) {
                                     const total = context.dataset.data.reduce((a, b) => a + b, 0);
                                     const percentage = ((context.raw / total) * 100).toFixed(1);
-                                    return context.label + ': ' + context.raw + ' (' + percentage + '%)';
+                                    return folderFullPaths[context.dataIndex] + ': ' + context.raw + ' (' + percentage + '%)';
                                 }
                             }
                         }
@@ -736,16 +737,12 @@ export function generateDashboardHtml(
                 }
             });
 
-            // Add legend with percentage (top 5)
-            const total = data.reduce((a, b) => a + b, 0);
+            // Show folder count
             const legend = document.getElementById('folderLegend');
-            folders.slice(0, 5).forEach((name, i) => {
-                const pct = ((data[i] / total) * 100).toFixed(1);
-                const item = document.createElement('div');
-                item.className = 'legend-item';
-                item.innerHTML = \`<div class="legend-color" style="background-color: \${folderColors[i]}"></div><span>\${name}: \${data[i]} (\${pct}%)</span>\`;
-                legend.appendChild(item);
-            });
+            const item = document.createElement('div');
+            item.className = 'legend-item';
+            item.innerHTML = \`<span>\${folders.length} folders</span>\`;
+            legend.appendChild(item);
         })();
 
         // ========== Chart 3: Labels Per Image (Full Data) ==========


### PR DESCRIPTION
## Summary

- 移除 Folder Distribution 图例中的文件夹名和百分比显示
- 图例只展示文件夹总数（如 "4 folders"）
- 鼠标悬停 tooltip 显示完整文件夹路径
- 取消饼状图最多 10 个文件夹的限制

## Changes

**Dashboard HTML**
- `src/utils/dashboardHtml.ts`: 优化 Folder Distribution 图例显示和 tooltip 内容，移除数量限制

## Test Plan

- [ ] 打开数据集统计面板
- [ ] 确认 Folder Distribution 图例只显示文件夹数量
- [ ] 鼠标悬停饼图扇区，确认显示完整文件夹路径
- [ ] 包含超过 10 个文件夹的数据集能完整显示所有分类