### PR TITLE
ci: 纯文档更新时跳过发布和版本递增

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -11,7 +11,11 @@ permissions:
 jobs:
   publish-to-marketplace:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
+    # 发布条件:
+    # 1. 在 main 分支
+    # 2. commit message 不含 [skip ci]
+    # 3. commit message 不以 'docs:' 开头 (纯文档更新跳过发布)
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]') && !startsWith(github.event.head_commit.message, 'docs:')
     env:
       # HaaLeo/publish-vscode-extension@v2 仍使用 node20，暂无更新版本
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -13,7 +13,11 @@ permissions:
 jobs:
   update-version:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' && !contains(github.event.head_commit.message, '[skip ci]')
+    # 版本更新条件:
+    # 1. 在 dev 分支
+    # 2. commit message 不含 [skip ci]
+    # 3. commit message 不以 'docs:' 开头 (纯文档更新跳过版本递增)
+    if: github.ref == 'refs/heads/dev' && !contains(github.event.head_commit.message, '[skip ci]') && !startsWith(github.event.head_commit.message, 'docs:')
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
### Summary

- main 分支：当 commit message 以  开头时，跳过 Marketplace 发布
- dev 分支：当 commit message 以  开头时，跳过版本号自动递增
- 确保纯文档更新的 PR 不会触发不必要的 CI/CD 流程

### Changes

-  - 新增  跳过条件
-  - 新增  跳过条件

### Test Plan

- [ ] 合并到 main 后，验证以  开头的 commit 不会触发发布
- [ ] 验证正常的功能提交流程不受影响