### PR TITLE
ci: 优化纯文档更新检测逻辑（基于 .md 文件后缀）

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -9,13 +9,40 @@ permissions:
   contents: write
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_non_docs_changes: ${{ steps.check.outputs.has_non_docs_changes }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Check for non-documentation changes
+        id: check
+        run: |
+          # 获取变更文件列表
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # 检查是否有非 .md 文件变更
+          if echo "$CHANGED_FILES" | grep -qv "\.md$"; then
+            echo "has_non_docs_changes=true" >> $GITHUB_OUTPUT
+            echo "✅ Found code/configuration changes, will proceed with publish"
+          else
+            echo "has_non_docs_changes=false" >> $GITHUB_OUTPUT
+            echo "📝 Only documentation (.md) files changed, will skip publish"
+          fi
+
   publish-to-marketplace:
+    needs: check-changes
     runs-on: ubuntu-latest
     # 发布条件:
     # 1. 在 main 分支
     # 2. commit message 不含 [skip ci]
-    # 3. commit message 不以 'docs:' 开头 (纯文档更新跳过发布)
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]') && !startsWith(github.event.head_commit.message, 'docs:')
+    # 3. 存在非文档变更（即不是纯文档更新）
+    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]') && needs.check-changes.outputs.has_non_docs_changes == 'true'
     env:
       # HaaLeo/publish-vscode-extension@v2 仍使用 node20，暂无更新版本
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -11,13 +11,40 @@ permissions:
   contents: write
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_non_docs_changes: ${{ steps.check.outputs.has_non_docs_changes }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Check for non-documentation changes
+        id: check
+        run: |
+          # 获取变更文件列表
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # 检查是否有非 .md 文件变更
+          if echo "$CHANGED_FILES" | grep -qv "\.md$"; then
+            echo "has_non_docs_changes=true" >> $GITHUB_OUTPUT
+            echo "✅ Found code/configuration changes, will proceed with version increment"
+          else
+            echo "has_non_docs_changes=false" >> $GITHUB_OUTPUT
+            echo "📝 Only documentation (.md) files changed, will skip version increment"
+          fi
+
   update-version:
+    needs: check-changes
     runs-on: ubuntu-latest
     # 版本更新条件:
     # 1. 在 dev 分支
     # 2. commit message 不含 [skip ci]
-    # 3. commit message 不以 'docs:' 开头 (纯文档更新跳过版本递增)
-    if: github.ref == 'refs/heads/dev' && !contains(github.event.head_commit.message, '[skip ci]') && !startsWith(github.event.head_commit.message, 'docs:')
+    # 3. 存在非文档变更（即不是纯文档更新）
+    if: github.ref == 'refs/heads/dev' && !contains(github.event.head_commit.message, '[skip ci]') && needs.check-changes.outputs.has_non_docs_changes == 'true'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -27,11 +54,11 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24.x'
-      
+
       - name: Get current version
         id: current_version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-        
+
       - name: Bump patch version (third number)
         id: new_version
         run: |
@@ -42,7 +69,7 @@ jobs:
           NEWPATCH=$((PATCH + 1))
           NEWVERSION="$MAJOR.$MINOR.$NEWPATCH"
           echo "version=$NEWVERSION" >> $GITHUB_OUTPUT
-          
+
       - name: Update package.json version
         run: |
           npm version ${{ steps.new_version.outputs.version }} --no-git-tag-version
@@ -64,15 +91,15 @@ jobs:
           git commit -m "Bump patch version to ${{ steps.new_version.outputs.version }} for dev release [skip ci]"
           git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}
           git push
-      
+
       - name: Delete package-lock.json and install dependencies
         run: |
           rm -f package-lock.json
           npm install --no-package-lock --ignore-scripts
-        
+
       - name: Build extension with webpack (development)
         run: npm run build:dev
-        
+
       - name: Package extension
         run: |
           npm install -g @vscode/vsce

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -325,8 +325,10 @@ When code is pushed to the `dev` branch, the following happens automatically:
 
 **Skip conditions** (version increment is skipped if any condition is met):
 - Commit message contains `[skip ci]`
-- Commit message starts with `docs:` (documentation-only changes)
+- **All changed files are `.md` documentation files (based on file content detection, not commit message)
 - Only `package.json` was modified
+
+> 💡 **Detection mechanism**: Analyzes changed files via `git diff --name-only HEAD^ HEAD`. If all files have `.md` extension, it's considered documentation-only. This ensures changes merged from the `docs` branch are correctly identified even if the merge commit message doesn't start with `docs:`.
 
 ### Auto Publish Process (main branch)
 
@@ -340,7 +342,9 @@ When code is pushed to the `main` branch, the following happens automatically:
 
 **Skip conditions** (publish is skipped if any condition is met):
 - Commit message contains `[skip ci]`
-- Commit message starts with `docs:` (documentation-only changes)
+- **All changed files are `.md` documentation files (based on file content detection, not commit message)
+
+> 💡 **Detection mechanism**: Analyzes changed files via `git diff --name-only HEAD^ HEAD`. If all files have `.md` extension, it's considered documentation-only. This ensures changes merged from the `docs` branch are correctly identified even if the merge commit message doesn't start with `docs:`.
 
 ### Special Handling for Documentation-Only Changes
 

--- a/docs/DEVELOPMENT_CN.md
+++ b/docs/DEVELOPMENT_CN.md
@@ -325,8 +325,10 @@ feat: 添加COCO8-seg数据格式支持
 
 **跳过条件**（满足任一条件则不执行版本递增）：
 - commit message 包含 `[skip ci]`
-- commit message 以 `docs:` 开头（纯文档更新）
+- **所有变更文件都是 `.md` 文档文件**（基于文件内容检测，不是 commit message）
 - 修改的文件只有 `package.json`
+
+> 💡 **检测机制说明**：通过 `git diff --name-only HEAD^ HEAD` 分析变更文件，如果所有文件后缀都是 `.md`，则判定为纯文档更新。这确保了从 `docs` 分支合并过来的变更（即使 merge commit message 不是以 `docs:` 开头）也能被正确识别。
 
 ### 自动发布流程（main 分支）
 
@@ -340,7 +342,9 @@ feat: 添加COCO8-seg数据格式支持
 
 **跳过条件**（满足任一条件则不执行发布）：
 - commit message 包含 `[skip ci]`
-- commit message 以 `docs:` 开头（纯文档更新）
+- **所有变更文件都是 `.md` 文档文件**（基于文件内容检测，不是 commit message）
+
+> 💡 **检测机制说明**：通过 `git diff --name-only HEAD^ HEAD` 分析变更文件，如果所有文件后缀都是 `.md`，则判定为纯文档更新。这确保了从 `docs` 分支合并过来的变更（即使 merge commit message 不是以 `docs:` 开头）也能被正确识别。
 
 ### 纯文档更新的特殊处理
 


### PR DESCRIPTION
### Summary

- 🔧 **重要修复**: 改为基于文件内容检测纯文档更新（之前依赖 commit message 有缺陷）
- 📝 新增详细的 CI/CD 流程文档（中英文）
- 📊 更新数据集统计仪表板和 TreeView 功能文档
- 🗑️ 移除过时的迁移计划和快速入门文档
- ⚠️ **注意**: 本次包含 .yml 配置文件变更，合并后会触发发布

### Changes

**CI/CD 配置优化（核心修复）**
- `.github/workflows/main-publish.yml` - 新增 check-changes job，检测是否只有 .md 文件变更
- `.github/workflows/version-updater.yml` - 同样新增文件内容检测逻辑

**问题说明（已修复）**
> ❌ 之前的缺陷：依赖 commit message 以 `docs:` 开头
> 但 merge commit 是 `Merge pull request #40 from andaoai/docs`，不会匹配
>
> ✅ 修复方案：通过 `git diff --name-only HEAD^ HEAD` 分析变更文件
> 如果所有文件后缀都是 `.md`，则自动跳过发布/版本递增

**开发文档更新**
- `docs/DEVELOPMENT.md` - 更新 CI/CD 流程说明（英文）
- `docs/DEVELOPMENT_CN.md` - 更新 CI/CD 流程说明（中文）

**功能文档更新**
- `README.md` - 更新数据集统计仪表板和 TreeView 功能介绍
- `docs/README_CN.md` - 中文版本同步更新
- 添加数据集统计可视化截图

**移除过时文档**
- `docs/js-to-ts-migration-plan.md` - 已完成的迁移计划
- `docs/vsc-extension-quickstart.md` - VS Code 扩展快速入门

### Test Plan

- [ ] 合并到 main 后，验证下次纯文档更新（只有 .md 文件）会自动跳过发布
- [ ] 验证正常代码提交流程不受影响
- [ ] 确认中英文开发文档内容一致
- [ ] 确认 README 内容准确描述新功能